### PR TITLE
added possibility to login via redirect instead of popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a wrapper module to authenticate Angular applications to the Azure v2 en
  - Updated msal from 0.14 to 0.15.
 
 #### BREAKING CHANGES: 
- - authenticated() returns a Promise<boolean> instead of a boolean.
+ - authenticated() and getUser() return a Promise.
 
 ### 2.0.1
 - Updated for Angular 5

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ This is a wrapper module to authenticate Angular applications to the Azure v2 en
 
 ## Change Log
 
+### 2.0.2
+ - Added an option to redirect instead of the popup login
+ - Added configuration options navigateToLoginRequestUrl, redirectUrl and callback.
+ - Fixed authenticated() returning true when token is expired.
+ - Updated msal form 0.14 to 0.15.
+
+#### BREAKING CHANGES: 
+ - authenticated() returns a Promise<boolean> instead of a boolean.
+
 ### 2.0.1
 - Updated for Angular 5
 - Several improvements contributed by Marcelh1983
@@ -58,7 +67,20 @@ npm install msal-angular --save
     this.msalService.logout();
   }
 
-  get authenticated(): boolean {
+  get authenticated(): Promise<boolean> {
     return this.msalService.authenticated;
   }
 ```
+
+#### 3. Config
+
+ - clientID: Specifies the Azure AD client id/application Id of the calling web service;
+ - graphScopes: Allows the client to express the desired scope of the access request;
+ - signUpSignInPolicy: Name of the Sign-up or sign-in policy (optional*);
+ - tenant: Url of the tenant xxx.onmicrosoft.com (optional*)
+ - popup: show login popup or redirect (optional, default: true);
+ - navigateToLoginRequestUrl: Ability to turn off default navigation to start page after login. (optional, default: false);
+ - redirectUrl: Location to redirect, can be a relative of absolute url. (optional, default: window.location.href);
+ - callback: Callback function after login;
+
+* if signUpSignInPolicy or tenant will only be applied when both values are filled.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a wrapper module to authenticate Angular applications to the Azure v2 en
  - Added an option to redirect instead of the popup login
  - Added configuration options navigateToLoginRequestUrl, redirectUrl and callback.
  - Fixed authenticated() returning true when token is expired.
- - Updated msal form 0.14 to 0.15.
+ - Updated msal from 0.14 to 0.15.
 
 #### BREAKING CHANGES: 
  - authenticated() returns a Promise<boolean> instead of a boolean.
@@ -83,4 +83,4 @@ npm install msal-angular --save
  - redirectUrl: Location to redirect, can be a relative of absolute url. (optional, default: window.location.href);
  - callback: Callback function after login;
 
-* if signUpSignInPolicy or tenant will only be applied when both values are filled.
+\* signUpSignInPolicy and tenant will only be applied when both values are filled.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msal-angular",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,7 @@
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.6.tgz",
       "integrity": "sha512-gJrUKW9rDeVGP0pBNGDEEP/U+vBtgIVd1+52X5mc+dNFuUQdQ2kNTK5+fbDfwVstEWE86gloHlG2GS2Ga94R3Q==",
+      "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
@@ -37,6 +38,7 @@
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.6.tgz",
       "integrity": "sha512-BOkF7RM4VcqfIlQeOz17FucfocUmyZBsGIWxVSggeCBz2pQDyOUJ1IqrDh5c4yldW9G4Gjhhn/AkPykvPevI3w==",
+      "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
@@ -45,6 +47,7 @@
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.6.tgz",
       "integrity": "sha512-5jP0TeOCCM2SfXjC8306x6p3hdj7+GLuWsXuKyqozqdnr69RKI0vssY0XUzU0If/YsLWVoW/aY6wuiF8ybfIuA==",
+      "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
@@ -53,6 +56,7 @@
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-5.2.6.tgz",
       "integrity": "sha512-10Otnr5nmDWrlCpR5DTuDZmLj2hGf8WX1yFkfQ8H4EJWYe3YCTwGvz5D/smrWL6m6I2rOFgYOO3rFj9iYvMumA==",
+      "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
@@ -2830,9 +2834,9 @@
       }
     },
     "msal": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-0.1.4.tgz",
-      "integrity": "sha1-Og/Sr9qpImyNECaWJq4Pgsm5u80=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-0.1.5.tgz",
+      "integrity": "sha1-44jTyH0WzWKDnTIqpf0GG5mdqUw=",
       "requires": {
         "tslib": "1.7.1"
       }
@@ -3439,6 +3443,7 @@
       "version": "5.5.6",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
       "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
       "requires": {
         "symbol-observable": "1.0.1"
       }
@@ -3605,7 +3610,8 @@
     "symbol-observable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.3",
@@ -3871,7 +3877,8 @@
     "zone.js": {
       "version": "0.8.20",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.20.tgz",
-      "integrity": "sha512-FXlA37ErSXCMy5RNBcGFgCI/Zivqzr0D19GuvDxhcYIJc7xkFp6c29DKyODJu0Zo+EMyur/WPPgcBh1EHjB9jA=="
+      "integrity": "sha512-FXlA37ErSXCMy5RNBcGFgCI/Zivqzr0D19GuvDxhcYIJc7xkFp6c29DKyODJu0Zo+EMyur/WPPgcBh1EHjB9jA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "homepage": "https://github.com/benbaran/msal-angular#readme",
     "dependencies": {
-        "msal": "^0.1.4"
+        "msal": "^0.1.5"
     },
     "devDependencies": {
         "@angular/common": "^5.2.6",

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -6,6 +6,10 @@ export class MsalConfig {
     public signUpSignInPolicy?: string;
     public tenant?: string;
     public popup?: boolean = false;
-    public callback: tokenReceivedCallback = () => { };
+    public callback: tokenReceivedCallback =
+        (errorDesc: any, token: any, error: any, tokenType: any) => {
+            if (error) {
+                console.error(`${error} ${errorDesc}`);
+            };
+        }
 }
-

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -6,7 +6,7 @@ export class MsalConfig {
     public signUpSignInPolicy?: string;
     public tenant?: string;
     public popup?: boolean = false;
-    public callback: tokenReceivedCallback =
+    public callback?: tokenReceivedCallback =
         (errorDesc: any, token: any, error: any, tokenType: any) => {
             if (error) {
                 console.error(`${error} ${errorDesc}`);

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -3,5 +3,6 @@ export interface MsalConfig {
     graphScopes: string[];
     signUpSignInPolicy?: string;
     tenant?: string;
+    popup: boolean;
 }
 

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -5,7 +5,7 @@ export class MsalConfig {
     public graphScopes: string[];
     public signUpSignInPolicy?: string;
     public tenant?: string;
-    public popup?: boolean = false;
+    public popup?: boolean = true;
     public callback?: tokenReceivedCallback =
         (errorDesc: any, token: any, error: any, tokenType: any) => {
             if (error) {

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -6,6 +6,8 @@ export class MsalConfig {
     public signUpSignInPolicy?: string;
     public tenant?: string;
     public popup?: boolean = true;
+    public navigateToLoginRequestUrl? = false;
+    public redirectUrl? = window.location.href;
     public callback?: tokenReceivedCallback =
         (errorDesc: any, token: any, error: any, tokenType: any) => {
             if (error) {

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -1,17 +1,17 @@
-import { tokenReceivedCallback } from "msal/lib-commonjs/UserAgentApplication";
+import { tokenReceivedCallback } from 'msal/lib-commonjs/UserAgentApplication';
 
 export class MsalConfig {
     public clientID: string;
     public b2cScopes: string[];
     public signUpSignInPolicy?: string;
     public tenant?: string;
-    public popup?: boolean = true;
-    public navigateToLoginRequestUrl? = false;
-    public redirectUrl? = window.location.href;
+    public popup ? = true;
+    public navigateToLoginRequestUrl ? = false;
+    public redirectUrl ? = window.location.href;
     public callback?: tokenReceivedCallback =
         (errorDesc: any, token: any, error: any, tokenType: any) => {
             if (error) {
                 console.error(`${error} ${errorDesc}`);
-            };
+            }
         }
 }

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -2,7 +2,7 @@ import { tokenReceivedCallback } from "msal/lib-commonjs/UserAgentApplication";
 
 export class MsalConfig {
     public clientID: string;
-    public graphScopes: string[];
+    public b2cScopes: string[];
     public signUpSignInPolicy?: string;
     public tenant?: string;
     public popup?: boolean = true;

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -1,8 +1,11 @@
-export interface MsalConfig {
-    clientID: string;
-    graphScopes: string[];
-    signUpSignInPolicy?: string;
-    tenant?: string;
-    popup: boolean;
+import { tokenReceivedCallback } from "msal/lib-commonjs/UserAgentApplication";
+
+export class MsalConfig {
+    public clientID: string;
+    public graphScopes: string[];
+    public signUpSignInPolicy?: string;
+    public tenant?: string;
+    public popup?: boolean = false;
+    public callback: tokenReceivedCallback = () => { };
 }
 

--- a/src/msal-config.ts
+++ b/src/msal-config.ts
@@ -2,7 +2,7 @@ import { tokenReceivedCallback } from 'msal/lib-commonjs/UserAgentApplication';
 
 export class MsalConfig {
     public clientID: string;
-    public b2cScopes: string[];
+    public graphScopes: string[];
     public signUpSignInPolicy?: string;
     public tenant?: string;
     public popup ? = true;

--- a/src/msal.interceptor.ts
+++ b/src/msal.interceptor.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { MsalService } from './msal.service';
 import 'rxjs/add/observable/fromPromise';
-import 'rxjs/add/operator/mergeMap'
+import 'rxjs/add/operator/mergeMap';
 @Injectable()
 export class MsalInterceptor implements HttpInterceptor {
 
@@ -17,6 +17,6 @@ export class MsalInterceptor implements HttpInterceptor {
                     Authorization: JWT,
                 },
             });
-        })).mergeMap(req => next.handle(req));
+        })).mergeMap(r => next.handle(r));
     }
 }

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -43,11 +43,11 @@ export class MsalService {
   }
 
   public getToken(): Promise<string> {
-    return this.app.acquireTokenSilent(this.config.graphScopes)
+    return this.app.acquireTokenSilent(this.config.b2cScopes)
       .then(token => {
         return token;
       }).catch(error => {
-        return this.app.acquireTokenPopup(this.config.graphScopes)
+        return this.app.acquireTokenPopup(this.config.b2cScopes)
           .then(token => {
             return Promise.resolve(token);
           }).catch(innererror => {

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -14,26 +14,20 @@ export class MsalService {
 
   constructor(@Inject(MSAL_CONFIG) private config: MsalConfig) {
     const authority = (config.tenant && config.signUpSignInPolicy) ?
-      `https://login.microsoftonline.com/tfp/${config.tenant}/${config.signUpSignInPolicy}` : '';
-    this.app = new Msal.UserAgentApplication(
-      config.clientID,
-      authority,
-      this.authCallback,
-      {
-        redirectUri: window.location.origin
-      });
-    this.app = new Msal.UserAgentApplication(config.clientID, authority, () => { });
+      `https://login.microsoftonline.com/tfp/${config.tenant}/${config.signUpSignInPolicy}` :
+      '';
+    this.app = new Msal.UserAgentApplication(config.clientID, authority, config.callback, { navigateToLoginRequestUrl: false });
   }
 
   get authenticated() {
-    if(!this.user) {
+    if (!this.user) {
       this.user = this.app.getUser();
     }
     return !!this.user;
   }
 
-  public getUser(){
-    if(this.authenticated)
+  public getUser() {
+    if (this.authenticated)
       return this.user;
     return {};
   }
@@ -65,7 +59,7 @@ export class MsalService {
       Promise.resolve(this.app.getUser());
     });
   }
-  
+
   public getToken(): Promise<string> {
     return this.app.acquireTokenSilent(this.config.graphScopes)
       .then(token => {
@@ -81,7 +75,7 @@ export class MsalService {
   }
 
   public logout() {
-    this.user=null;
+    this.user = null;
     this.app.logout();
   }
 

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -95,9 +95,7 @@ export class MsalService {
 
   private getFullUrl(url: string): string {
     const pat = /^https?:\/\//i;
-    const fullUrl = pat.test(url) ? url : this.origin() + url;
-    console.log(fullUrl);
-    return fullUrl;
+    return pat.test(url) ? url : this.origin() + url;
   }
 
   private origin() {

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -21,74 +21,75 @@ export class MsalService {
         navigateToLoginRequestUrl: this.config.navigateToLoginRequestUrl,
         redirectUri: this.config.redirectUrl
       });
-}
+  }
 
 
   public getUser() {
-  if (this.authenticated)
-    return this.user;
-  return {};
-}
+    if (this.authenticated) {
+      return this.user;
+    }
+    return {};
+  }
 
 
-get authenticated() {
-  return this.token.then(t => !!t);
-}
+  get authenticated() {
+    return this.token.then(t => !!t);
+  }
 
 
-get token() {
-  return this.getToken();
-}
+  get token() {
+    return this.getToken();
+  }
 
   public login() {
-  return this.config.popup ?
-    this.loginPopup() :
-    this.loginRedirect()
-}
+    return this.config.popup ?
+      this.loginPopup() :
+      this.loginRedirect();
+  }
 
-  public getToken(): Promise < string > {
-  return this.app.acquireTokenSilent(this.config.b2cScopes)
-    .then(token => {
-      return token;
-    }).catch(error => {
-      return this.app.acquireTokenPopup(this.config.b2cScopes)
-        .then(token => {
-          return Promise.resolve(token);
-        }).catch(innererror => {
-          return Promise.resolve('');
-        });
-    });
-}
-
-  public logout() {
-  this.user = null;
-  this.app.logout();
-}
-
-  public loginPopup() {
-  return this.app.loginPopup(this.config.b2cScopes).then((idToken) => {
-    this.app.acquireTokenSilent(this.config.b2cScopes).then(
-      (token: string) => {
-        return Promise.resolve(token);
-      }, (error: string) => {
-        this.app.acquireTokenPopup(this.config.b2cScopes).then(
-          (token: string) => {
+  public getToken(): Promise<string> {
+    return this.app.acquireTokenSilent(this.config.b2cScopes)
+      .then(token => {
+        return token;
+      }).catch(error => {
+        return this.app.acquireTokenPopup(this.config.b2cScopes)
+          .then(token => {
             return Promise.resolve(token);
-          }, (error: any) => {
-            console.log("Error acquiring the popup:\n" + error);
+          }).catch(innererror => {
             return Promise.resolve('');
           });
-      })
-  }, (error: any) => {
-    console.log("Error during login:\n" + error);
-    return Promise.resolve('');
-  });
-}
+      });
+  }
+
+  public logout() {
+    this.user = null;
+    this.app.logout();
+  }
+
+  public loginPopup() {
+    return this.app.loginPopup(this.config.b2cScopes).then((idToken) => {
+      this.app.acquireTokenSilent(this.config.b2cScopes).then(
+        (token: string) => {
+          return Promise.resolve(token);
+        }, (error: any) => {
+          this.app.acquireTokenPopup(this.config.b2cScopes).then(
+            (token: string) => {
+              return Promise.resolve(token);
+            }, (innererror: any) => {
+              console.log('Error acquiring the popup:\n' + innererror);
+              return Promise.resolve('');
+            });
+        });
+    }, (error: any) => {
+      console.log('Error during login:\n' + error);
+      return Promise.resolve('');
+    });
+  }
 
   private loginRedirect() {
-  this.app.loginRedirect(this.config.b2cScopes);
-  return this.getToken().then(() => {
-    Promise.resolve(this.app.getUser());
-  });
-}
+    this.app.loginRedirect(this.config.b2cScopes);
+    return this.getToken().then(() => {
+      Promise.resolve(this.app.getUser());
+    });
+  }
 }

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -61,17 +61,28 @@ export class MsalService {
     this.app.logout();
   }
 
-  private loginPopup() {
-    return this.app.loginPopup(this.config.graphScopes)
-      .then((idToken) => {
-        return this.getToken().then(() => {
-          Promise.resolve(this.app.getUser());
-        });
-      });
+  public loginPopup() {
+   return this.app.loginPopup(this.config.b2cScopes).then((idToken) => {
+      this.app.acquireTokenSilent(this.config.b2cScopes).then(
+        (token: string) => {
+          return Promise.resolve(token);
+        }, (error: string) => {
+          this.app.acquireTokenPopup(this.config.b2cScopes).then(
+            (token: string) => {
+              return Promise.resolve(token);
+            }, (error: any) => {
+              console.log("Error acquiring the popup:\n" + error);
+              return Promise.resolve('');
+            });
+        })
+    }, (error: any) => {
+      console.log("Error during login:\n" + error);
+      return Promise.resolve('');
+    });
   }
 
   private loginRedirect() {
-    this.app.loginRedirect(this.config.graphScopes);
+    this.app.loginRedirect(this.config.b2cScopes);
     return this.getToken().then(() => {
       Promise.resolve(this.app.getUser());
     });

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -48,11 +48,11 @@ export class MsalService {
   }
 
   public getToken(): Promise<string> {
-    return this.app.acquireTokenSilent(this.config.b2cScopes)
+    return this.app.acquireTokenSilent(this.config.graphScopes)
       .then(token => {
         return token;
       }).catch(error => {
-        return this.app.acquireTokenPopup(this.config.b2cScopes)
+        return this.app.acquireTokenPopup(this.config.graphScopes)
           .then(token => {
             return Promise.resolve(token);
           }).catch(innererror => {
@@ -67,12 +67,12 @@ export class MsalService {
   }
 
   public loginPopup() {
-    return this.app.loginPopup(this.config.b2cScopes).then((idToken) => {
-      this.app.acquireTokenSilent(this.config.b2cScopes).then(
+    return this.app.loginPopup(this.config.graphScopes).then((idToken) => {
+      this.app.acquireTokenSilent(this.config.graphScopes).then(
         (token: string) => {
           return Promise.resolve(token);
         }, (error: any) => {
-          this.app.acquireTokenPopup(this.config.b2cScopes).then(
+          this.app.acquireTokenPopup(this.config.graphScopes).then(
             (token: string) => {
               return Promise.resolve(token);
             }, (innererror: any) => {
@@ -87,13 +87,14 @@ export class MsalService {
   }
 
   private loginRedirect() {
-    this.app.loginRedirect(this.config.b2cScopes);
+    this.app.loginRedirect(this.config.graphScopes);
     return this.getToken().then(() => {
       Promise.resolve(this.app.getUser());
     });
   }
 
   private getFullUrl(url: string): string {
+    // this create a absolute url from a relative one.
     const pat = /^https?:\/\//i;
     return pat.test(url) ? url : this.origin() + url;
   }

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -16,75 +16,79 @@ export class MsalService {
     const authority = (config.tenant && config.signUpSignInPolicy) ?
       `https://login.microsoftonline.com/tfp/${config.tenant}/${config.signUpSignInPolicy}` :
       '';
-    this.app = new Msal.UserAgentApplication(config.clientID, authority, config.callback, { navigateToLoginRequestUrl: false });
-  }
+    this.app = new Msal.UserAgentApplication(config.clientID, authority, config.callback,
+      {
+        navigateToLoginRequestUrl: this.config.navigateToLoginRequestUrl,
+        redirectUri: this.config.redirectUrl
+      });
+}
 
 
   public getUser() {
-    if (this.authenticated)
-      return this.user;
-    return {};
-  }
+  if (this.authenticated)
+    return this.user;
+  return {};
+}
 
 
-  get authenticated() {
-    return this.token.then(t => !!t);
-  }
+get authenticated() {
+  return this.token.then(t => !!t);
+}
 
 
-  get token() {
-    return this.getToken();
-  }
+get token() {
+  return this.getToken();
+}
 
   public login() {
-    return this.config.popup ?
-      this.loginPopup() :
-      this.loginRedirect()
-  }
+  return this.config.popup ?
+    this.loginPopup() :
+    this.loginRedirect()
+}
 
-  public getToken(): Promise<string> {
-    return this.app.acquireTokenSilent(this.config.b2cScopes)
-      .then(token => {
-        return token;
-      }).catch(error => {
-        return this.app.acquireTokenPopup(this.config.b2cScopes)
-          .then(token => {
-            return Promise.resolve(token);
-          }).catch(innererror => {
-            return Promise.resolve('');
-          });
-      });
-  }
+  public getToken(): Promise < string > {
+  return this.app.acquireTokenSilent(this.config.b2cScopes)
+    .then(token => {
+      return token;
+    }).catch(error => {
+      return this.app.acquireTokenPopup(this.config.b2cScopes)
+        .then(token => {
+          return Promise.resolve(token);
+        }).catch(innererror => {
+          return Promise.resolve('');
+        });
+    });
+}
 
   public logout() {
-    this.user = null;
-    this.app.logout();
-  }
+  this.user = null;
+  this.app.logout();
+}
 
   public loginPopup() {
-   return this.app.loginPopup(this.config.b2cScopes).then((idToken) => {
-      this.app.acquireTokenSilent(this.config.b2cScopes).then(
-        (token: string) => {
-          return Promise.resolve(token);
-        }, (error: string) => {
-          this.app.acquireTokenPopup(this.config.b2cScopes).then(
-            (token: string) => {
-              return Promise.resolve(token);
-            }, (error: any) => {
-              console.log("Error acquiring the popup:\n" + error);
-              return Promise.resolve('');
-            });
-        })
-    }, (error: any) => {
-      console.log("Error during login:\n" + error);
-      return Promise.resolve('');
-    });
-  }
+  return this.app.loginPopup(this.config.b2cScopes).then((idToken) => {
+    this.app.acquireTokenSilent(this.config.b2cScopes).then(
+      (token: string) => {
+        return Promise.resolve(token);
+      }, (error: string) => {
+        this.app.acquireTokenPopup(this.config.b2cScopes).then(
+          (token: string) => {
+            return Promise.resolve(token);
+          }, (error: any) => {
+            console.log("Error acquiring the popup:\n" + error);
+            return Promise.resolve('');
+          });
+      })
+  }, (error: any) => {
+    console.log("Error during login:\n" + error);
+    return Promise.resolve('');
+  });
+}
 
   private loginRedirect() {
-    this.app.loginRedirect(this.config.b2cScopes);
-    return this.getToken().then(() => {
-      Promise.resolve(this.app.getUser());
-    });
-  }
+  this.app.loginRedirect(this.config.b2cScopes);
+  return this.getToken().then(() => {
+    Promise.resolve(this.app.getUser());
+  });
+}
 }

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -12,9 +12,8 @@ export class MsalService {
   private app: Msal.UserAgentApplication;
 
   constructor(@Inject(MSAL_CONFIG) private config: MsalConfig) {
-    const authority = (config.tenant && config.signUpSignInPolicy) ? `https://login.microsoftonline.com/tfp/${config.tenant}/${config.signUpSignInPolicy}` : '';
-    // //const authority = (config.tenant && config.signUpSignInPolicy) ?
-    // `https://login.microsoftonline.com/tfp/${config.tenant}/${config.signUpSignInPolicy}` :    "";
+    const authority = (config.tenant && config.signUpSignInPolicy) ? 
+      `https://login.microsoftonline.com/tfp/${config.tenant}/${config.signUpSignInPolicy}` : '';
     this.app = new Msal.UserAgentApplication(
       config.clientID,
       authority,
@@ -51,7 +50,6 @@ export class MsalService {
           .then(token => {
             return Promise.resolve(token);
           }).catch(innererror => {
-            console.error('Could not retrieve token from popup.', innererror);
             return Promise.resolve('');
           });
       });

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -14,8 +14,7 @@ export class MsalService {
 
   constructor(@Inject(MSAL_CONFIG) private config: MsalConfig) {
     const authority = (config.tenant && config.signUpSignInPolicy) ?
-      `https://login.microsoftonline.com/tfp/${config.tenant}/${config.signUpSignInPolicy}` :
-      '';
+      `https://login.microsoftonline.com/tfp/${config.tenant}/${config.signUpSignInPolicy}` : '';
     this.app = new Msal.UserAgentApplication(config.clientID, authority, config.callback,
       {
         navigateToLoginRequestUrl: this.config.navigateToLoginRequestUrl,
@@ -23,19 +22,13 @@ export class MsalService {
       });
   }
 
-
   public getUser() {
-    if (this.authenticated) {
-      return this.user;
-    }
-    return {};
+    return this.authenticated.then(isauthenticated => isauthenticated ? this.user : {});
   }
-
 
   get authenticated() {
     return this.token.then(t => !!t);
   }
-
 
   get token() {
     return this.getToken();

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -19,7 +19,7 @@ export class MsalService {
     this.app = new Msal.UserAgentApplication(config.clientID, authority, config.callback,
       {
         navigateToLoginRequestUrl: this.config.navigateToLoginRequestUrl,
-        redirectUri: this.config.redirectUrl
+        redirectUri: this.getFullUrl(this.config.redirectUrl)
       });
   }
 
@@ -91,5 +91,17 @@ export class MsalService {
     return this.getToken().then(() => {
       Promise.resolve(this.app.getUser());
     });
+  }
+
+  private getFullUrl(url: string): string {
+    const pat = /^https?:\/\//i;
+    const fullUrl = pat.test(url) ? url : this.origin() + url;
+    console.log(fullUrl);
+    return fullUrl;
+  }
+
+  private origin() {
+    return (window.location.origin) ? window.location.origin :
+      window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
   }
 }

--- a/src/msal.service.ts
+++ b/src/msal.service.ts
@@ -28,7 +28,7 @@ export class MsalService {
 
 
   get authenticated() {
-    return !!this.app.getUser();
+    return this.token.then(t => !!t);
   }
 
 


### PR DESCRIPTION
Hi benbaran.

This pull request contain too much check-in, we have been struggling to get things working in our application and had to try some things. I updated the readme with the changes I made. The changes are mainly because we wanted a login via redirect and because isAuthenticated returned true if the session is expired.

The default values of the new config values should be same as they were, so if you don't change anything it should work as before.

The reason we use the redirect login is because we have a public part of our application and you can login while your in the public part. This is not a single url. So this can be localhost:4200/{someVariableName} since you cannot specify a wildcard in the reply url in Azure it will always redirect you to the first reply url. 

This can be fix by using HashLocationStrategy but that gives problems because AzureAD replies with a hash as well. e.g. localhost:4200#error?xxx or localhost:4200#state?xx what causes a unknown route error in Angular. 

My solution now : add localhost:4200/login to the reply urls in AzureAD. On the frontend: add last known location to the localstorage, navigate to /login and call msalService.login so it will redirect to xxx.onmicrosoft.com after login it redirects to localhost:4200/login and because I check if the user is authenticated I navigate to the last known url from the localstorage. It's a hack but necessary since reply url's don't support wildcards.

Hope you can merge my changeset so I can get rid of this fork. But please feel free to decline :).

Regards, Marcel
